### PR TITLE
Adds support for showing only owned games in want to play page

### DIFF
--- a/components/filterItems.js
+++ b/components/filterItems.js
@@ -1,0 +1,40 @@
+import cookie from '~/components/cookie.js'
+import filter from 'lodash/filter'
+import get from 'lodash/get'
+import intersection from 'lodash/intersection'
+
+export default function filterItems (items, owned = true) {
+  return filter(items, (item) => {
+    let bestnum = false
+    if (cookie.get('bestatleast')) {
+      const highestNum = get(item, 'bggbestplayers', '').split(',').pop()
+      if (highestNum) {
+        bestnum = +highestNum >= this.bestnum
+      }
+    } else {
+      bestnum = get(item, 'bggbestplayers', '').split(',').includes(this.bestnum)
+    }
+
+    let mech = true
+
+    if (this.mechShow && this.mechShow.length > 0) {
+      mech = intersection(this.mechShow, item.mech).length === this.mechShow.length
+    }
+
+    if (this.mechHide && this.mechHide.length > 0 && mech) {
+      mech = !intersection(this.mechHide, item.mech).length > 0
+    }
+
+    return (!this.bestnum || bestnum) &&
+    (!this.recnum || get(item, 'bggrecplayers', '').split(',').includes(this.recnum)) &&
+    (!this.mintime || item.playingtime >= this.mintime) &&
+    (!this.maxtime || item.playingtime <= this.maxtime) &&
+    (!this.supplayer || (item.minplayer <= this.supplayer && item.maxplayer >= this.supplayer)) &&
+    (!this.maxweight || item.weight <= this.maxweight) &&
+    (!this.minweight || item.weight >= this.minweight) &&
+    ((cookie.get('showexp') === 'false' && item.type !== 'e') || cookie.get('showexp') === 'true') &&
+    ((cookie.get('showexp') === 'true' && item.type === 'e' && item.average >= cookie.get('expmin')) || item.type !== 'e') &&
+    (!this.playlessthan || item.numplays <= this.playlessthan) &&
+    (owned ? item.own : true) && mech
+  })
+};

--- a/pages/want-to-play.vue
+++ b/pages/want-to-play.vue
@@ -38,6 +38,18 @@
                       </span>
                     </b-button>
                   </b-col>
+                  <b-col sm="auto">
+                    <b-button size="sm" variant="primary" @click="ownedGames = !ownedGames">
+                      <span v-if="ownedGames">
+                        <i class="fa fa-users" aria-hidden="true"></i>
+                        Show All Games
+                      </span>
+                      <span v-if="!ownedGames">
+                        <i class="fa fa-user" aria-hidden="true"></i>
+                        Show Only Owned Games
+                      </span>
+                    </b-button>
+                  </b-col>
               </b-row>
             </b-container>
             <v-table :games="filteredItem()" :headers="tableHeader" v-if="listView"></v-table>
@@ -109,6 +121,7 @@ export default {
               minplayer: parseFloat(item.stats._minplayers),
               name: item.name.__text,
               numplays: parseFloat(item.numplays),
+              own: _.get(item, 'status._own') === '1',
               playingtime: parseFloat(item.stats._playingtime),
               rank,
               rating: parseFloat(item.stats.rating._value)
@@ -135,6 +148,7 @@ export default {
       maxweight: this.$route.query.maxweight || undefined,
       mintime: this.$route.query.mintime || undefined,
       minweight: this.$route.query.minweight || undefined,
+      ownedGames: false,
       recnum: this.$route.query.recnum || undefined,
       tableHeader: [
         {key: '', value: '', hide: this.$route.query.noimage},
@@ -188,13 +202,15 @@ export default {
         } else {
           bestnum = _.get(item, 'bggbestplayers', '').split(',').includes(this.bestnum)
         }
+        console.log(this, item)
         return (!this.bestnum || bestnum) &&
         (!this.recnum || _.get(item, 'bggrecplayers', '').split(',').includes(this.recnum)) &&
         (!this.mintime || item.playingtime >= this.mintime) &&
         (!this.maxtime || item.playingtime <= this.maxtime) &&
         (!this.supplayer || (item.minplayer <= this.supplayer && item.maxplayer >= this.supplayer)) &&
         (!this.maxweight || item.weight <= this.maxweight) &&
-        (!this.minweight || item.weight >= this.minweight)
+        (!this.minweight || item.weight >= this.minweight) &&
+        (this.ownedGames ? item.own : true)
       })
     }
   }

--- a/pages/want-to-play.vue
+++ b/pages/want-to-play.vue
@@ -52,8 +52,8 @@
                   </b-col>
               </b-row>
             </b-container>
-            <v-table :games="filteredItem()" :headers="tableHeader" v-if="listView"></v-table>
-            <v-grid :games="filteredItem()" v-if="!listView"></v-grid>
+            <v-table :games="filteredItem(this.items, this.ownedGames)" :headers="tableHeader" v-if="listView"></v-table>
+            <v-grid :games="filteredItem(this.items, this.ownedGames)" v-if="!listView"></v-grid>
           </b-col>
         </b-row>
       </b-container>
@@ -70,6 +70,7 @@ import VGrid from '~/components/v-grid.vue'
 import VRefresh from '~/components/v-refresh.vue'
 import VLoader from '~/components/v-loader.vue'
 import VTable from '~/components/v-table.vue'
+import filterItems from '~/components/filterItems.js'
 import X2JS from 'x2js'
 var _ = require('lodash')
 
@@ -191,28 +192,8 @@ export default {
       }
       return encodeURI(link)
     },
-    filteredItem: function () {
-      return this.items.filter((item) => {
-        let bestnum = false
-        if (cookie.get('bestatleast')) {
-          const highestNum = _.get(item, 'bggbestplayers', '').split(',').pop()
-          if (highestNum) {
-            bestnum = +highestNum >= this.bestnum
-          }
-        } else {
-          bestnum = _.get(item, 'bggbestplayers', '').split(',').includes(this.bestnum)
-        }
-        console.log(this, item)
-        return (!this.bestnum || bestnum) &&
-        (!this.recnum || _.get(item, 'bggrecplayers', '').split(',').includes(this.recnum)) &&
-        (!this.mintime || item.playingtime >= this.mintime) &&
-        (!this.maxtime || item.playingtime <= this.maxtime) &&
-        (!this.supplayer || (item.minplayer <= this.supplayer && item.maxplayer >= this.supplayer)) &&
-        (!this.maxweight || item.weight <= this.maxweight) &&
-        (!this.minweight || item.weight >= this.minweight) &&
-        (this.ownedGames ? item.own : true)
-      })
-    }
+
+    filteredItem: filterItems
   }
 }
 </script>


### PR DESCRIPTION
This adds support for showing only a user's owned games in the "want to play" context.

Additionally, it splits the filter logic into a separate file so it can be shared across different contexts.

gameshelf/gameshelf.github.io#27