### PR TITLE
Cache API requests sent to BGG

### DIFF
--- a/actions/combineCollections.js
+++ b/actions/combineCollections.js
@@ -1,0 +1,59 @@
+import X2JS from 'x2js'
+import Game from '~/components/Game'
+import get from 'lodash/get'
+
+function parse (result = {}, items) { // eslint-disable-line
+  const x2js = new X2JS()
+  const { data } = result
+
+  const games = x2js.xml2js(data)
+
+  let userId = get(result, 'config.params.username')
+
+  let rank
+  get(games, 'items.item', []).forEach(item => {
+    if (get(item, 'stats.rating.ranks.rank.length', false)) {
+      rank = parseFloat(item.stats.rating.ranks.rank[0]._value)
+    } else {
+      rank = parseFloat(get(item, 'stats.rating.ranks.rank._value'))
+    }
+
+    let gameId = item._objectid
+    let numplays = parseFloat(item.numplays)
+    let rating = parseFloat(item.stats.rating._value)
+    if (items[gameId]) {
+      items[gameId].users[userId] = {
+        numplays,
+        rating: rating || 0
+      }
+      items[gameId].numplays += numplays || 0
+      if (!items[gameId].own) {
+        items[gameId].own = get(item, 'status._own') === '1'
+      }
+    } else {
+      items[gameId] = (new Game({
+        average: parseFloat(get(item, 'stats.rating.average._value')),
+        id: gameId,
+        imageUrl: item.thumbnail,
+        maxplayer: parseFloat(item.stats._maxplayers),
+        minplayer: parseFloat(item.stats._minplayers),
+        name: item.name.__text,
+        numplays,
+        own: get(item, 'status._own') === '1',
+        playingtime: parseFloat(item.stats._playingtime),
+        rank,
+        rating,
+        userId
+      }))
+    }
+  })
+  return items
+}
+
+export default function combineCollections (collections = []) {
+  const items = {}
+  return collections.reduce((accumulator, collection) => {
+    // const { data } = collection
+    return parse(collection, accumulator)
+  }, items)
+}

--- a/actions/fetchCollection.js
+++ b/actions/fetchCollection.js
@@ -1,0 +1,11 @@
+import axios from 'axios'
+
+export default async function fetchCollection (userId) {
+  const result = await axios.get('https://www.boardgamegeek.com/xmlapi2/collection', {
+    params: {
+      stats: 1,
+      username: userId.trim()
+    }
+  })
+  return result
+}

--- a/actions/fetchCollection.js
+++ b/actions/fetchCollection.js
@@ -1,11 +1,21 @@
 import axios from 'axios'
+import pickBy from 'lodash/pickBy'
 
-export default async function fetchCollection (userId) {
+export default async function fetchCollection (userId, {
+  wantToPlay,
+  trade,
+  own
+}) {
   const result = await axios.get('https://www.boardgamegeek.com/xmlapi2/collection', {
-    params: {
+    params: pickBy({
       stats: 1,
-      username: userId.trim()
-    }
+      username: userId.trim(),
+      wanttoplay: wantToPlay,
+      trade,
+      own
+    }, (val, key) => {
+      return typeof val !== 'undefined'
+    })
   })
   return result
 }

--- a/actions/fetchCollection.js
+++ b/actions/fetchCollection.js
@@ -4,7 +4,8 @@ import pickBy from 'lodash/pickBy'
 export default async function fetchCollection (userId, {
   wantToPlay,
   trade,
-  own
+  own,
+  wishlist
 }) {
   const result = await axios.get('https://www.boardgamegeek.com/xmlapi2/collection', {
     params: pickBy({
@@ -12,7 +13,8 @@ export default async function fetchCollection (userId, {
       username: userId.trim(),
       wanttoplay: wantToPlay,
       trade,
-      own
+      own,
+      wishlist
     }, (val, key) => {
       return typeof val !== 'undefined'
     })

--- a/actions/fetchCollection.js
+++ b/actions/fetchCollection.js
@@ -7,7 +7,7 @@ export default async function fetchCollection (userId, {
   own,
   wishlist
 }) {
-  const result = await axios.get('https://www.boardgamegeek.com/xmlapi2/collection', {
+  return axios.get('https://www.boardgamegeek.com/xmlapi2/collection', {
     params: pickBy({
       stats: 1,
       username: userId.trim(),
@@ -19,5 +19,4 @@ export default async function fetchCollection (userId, {
       return typeof val !== 'undefined'
     })
   })
-  return result
 }

--- a/components/LocalStorage.js
+++ b/components/LocalStorage.js
@@ -1,0 +1,16 @@
+export default class LocalStorage {
+  constructor (localStorage = null) {
+    this.localStorage = localStorage || window.localStorage
+  }
+  get (query) {
+    try {
+      const data = this.localStorage.getItem(query)
+      return JSON.parse(data)
+    } catch (e) {
+      return null
+    }
+  }
+  set (query, data) {
+    this.localStorage.setItem(query, JSON.stringify(data))
+  }
+}

--- a/components/LocalStorage.js
+++ b/components/LocalStorage.js
@@ -13,4 +13,11 @@ export default class LocalStorage {
   set (query, data) {
     this.localStorage.setItem(query, JSON.stringify(data))
   }
+  clear (expression) {
+    Object.keys(this.localStorage).forEach(key => {
+      if (key.match(expression)) {
+        this.localStorage.removeItem(key)
+      }
+    })
+  }
 }

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -1,14 +1,26 @@
 <template>
-  <div class="header">
-    <nuxt-link to="/" exact>Collection</nuxt-link>
-    <nuxt-link to="/want-to-play">Want To Play</nuxt-link>
-    <nuxt-link to="/wishlist">Wishlist</nuxt-link>
-    <nuxt-link to="/trade-sale">Trade/Sale</nuxt-link>
-    <nuxt-link to="/latest-100-plays">Latest 100 Plays</nuxt-link>
-    <nuxt-link to="/help">Help</nuxt-link>
+  <b-nav class="header">
+    <b-nav-item>
+      <nuxt-link to="/" exact>Collection</nuxt-link>
+    </b-nav-item>
+    <b-nav-item>
+      <nuxt-link to="/want-to-play">Want To Play</nuxt-link>
+    </b-nav-item>
+    <b-nav-item>
+      <nuxt-link to="/wishlist">Wishlist</nuxt-link>
+    </b-nav-item>
+    <b-nav-item>
+      <nuxt-link to="/trade-sale">Trade/Sale</nuxt-link>
+    </b-nav-item>
+    <b-nav-item>
+      <nuxt-link to="/latest-100-plays">Latest 100 Plays</nuxt-link>
+    </b-nav-item>
+    <b-nav-item>
+      <nuxt-link to="/help">Help</nuxt-link>
+    </b-nav-item>
     <!-- <nuxt-link to="/about">About</nuxt-link> -->
     <!-- <nuxt-link to="/want-to-buy">Want To Buy</nuxt-link> -->
-  </div>
+  </b-nav>
 </template>
 
 <script>
@@ -23,10 +35,11 @@ export default {
 .header {
   display: flex;
   flex: 1;
+  margin-bottom: 20px;
+  font-size: 14px;
+  font-size: .875rem;
 }
 a {
-  margin-right: 20px;
-  font-size: 14px;
   color: #999;
   text-decoration: none;
   text-transform: uppercase;

--- a/components/Username.vue
+++ b/components/Username.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="username-bar">
     <form @submit="change()">
-      <input type="text" v-model="username" placeholder="Your BGG username" />
+      <input type="text" v-model.trim="username" placeholder="Your BGG username" />
       <button @click="change()">Change user</button>
     </form>
   </div>
 </template>
 
 <script>
-import cookie from '~/components/cookie.js'
+import cookie from '~/components/cookie'
 
 export default {
   methods: {

--- a/components/Username.vue
+++ b/components/Username.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="username-bar">
-    <input type="text" v-model="username" placeholder="Your BGG username" />
-    <button @click="change()">Change user</button>
+    <form @submit="change()">
+      <input type="text" v-model="username" placeholder="Your BGG username" />
+      <button @click="change()">Change user</button>
+    </form>
   </div>
 </template>
 
@@ -14,9 +16,6 @@ export default {
       cookie.set('username', this.username)
       location.reload()
     }
-  },
-  data: {
-    username: cookie.get('username')
   },
   props: {
     username: {

--- a/components/filterItems.js
+++ b/components/filterItems.js
@@ -1,40 +1,50 @@
-import cookie from '~/components/cookie.js'
+import cookie from '~/components/cookie'
 import filter from 'lodash/filter'
 import get from 'lodash/get'
 import intersection from 'lodash/intersection'
 
-export default function filterItems (items, owned = true) {
+export default function filterItems (items, filters) {
+  const bestAtLeast = cookie.get('bestatleast')
+  const showExp = cookie.get('showexp')
+  const expmin = cookie.get('expmin')
   return filter(items, (item) => {
     let bestnum = false
-    if (cookie.get('bestatleast')) {
+    if (typeof filters !== 'object') {
+      filters = {}
+    }
+    if (bestAtLeast && bestAtLeast !== 'false') {
       const highestNum = get(item, 'bggbestplayers', '').split(',').pop()
       if (highestNum) {
-        bestnum = +highestNum >= this.bestnum
+        bestnum = +highestNum >= filters.bestnum
       }
     } else {
-      bestnum = get(item, 'bggbestplayers', '').split(',').includes(this.bestnum)
+      bestnum = get(item, 'bggbestplayers', '').split(',').includes(filters.bestnum)
     }
 
     let mech = true
 
-    if (this.mechShow && this.mechShow.length > 0) {
-      mech = intersection(this.mechShow, item.mech).length === this.mechShow.length
+    if (filters.mechShow && filters.mechShow.length > 0) {
+      mech = intersection(filters.mechShow, item.mech).length === filters.mechShow.length
     }
 
-    if (this.mechHide && this.mechHide.length > 0 && mech) {
-      mech = !intersection(this.mechHide, item.mech).length > 0
+    if (filters.mechHide && filters.mechHide.length > 0 && mech) {
+      mech = !intersection(filters.mechHide, item.mech).length > 0
     }
 
-    return (!this.bestnum || bestnum) &&
-    (!this.recnum || get(item, 'bggrecplayers', '').split(',').includes(this.recnum)) &&
-    (!this.mintime || item.playingtime >= this.mintime) &&
-    (!this.maxtime || item.playingtime <= this.maxtime) &&
-    (!this.supplayer || (item.minplayer <= this.supplayer && item.maxplayer >= this.supplayer)) &&
-    (!this.maxweight || item.weight <= this.maxweight) &&
-    (!this.minweight || item.weight >= this.minweight) &&
-    ((cookie.get('showexp') === 'false' && item.type !== 'e') || cookie.get('showexp') === 'true') &&
-    ((cookie.get('showexp') === 'true' && item.type === 'e' && item.average >= cookie.get('expmin')) || item.type !== 'e') &&
-    (!this.playlessthan || item.numplays <= this.playlessthan) &&
-    (owned ? item.own : true) && mech
+    const pass = (
+      (!filters.bestnum || bestnum) &&
+      (!filters.recnum || get(item, 'bggrecplayers', '').split(',').includes(filters.recnum)) &&
+      (!filters.mintime || item.playingtime >= filters.mintime) &&
+      (!filters.maxtime || item.playingtime <= filters.maxtime) &&
+      (!filters.supplayer || (item.minplayer <= filters.supplayer && item.maxplayer >= filters.supplayer)) &&
+      (!filters.maxweight || item.weight <= filters.maxweight) &&
+      (!filters.minweight || item.weight >= filters.minweight) &&
+      ((showExp === 'false' && item.type !== 'e') || showExp === 'true') &&
+      ((showExp === 'true' && item.type === 'e' && item.average >= expmin) || item.type !== 'e') &&
+      (!filters.playlessthan || item.numplays <= filters.playlessthan) &&
+      (typeof filters.ownedgames === 'boolean' && filters.ownedgames ? item.own : true) &&
+      mech
+    )
+    return pass
   })
 };

--- a/components/params.js
+++ b/components/params.js
@@ -1,0 +1,15 @@
+export default [
+  'userId',
+  'bestnum',
+  'maxtime',
+  'maxweight',
+  'mintime',
+  'minweight',
+  'recnum',
+  'supplayer',
+  'playlessthan',
+  'showexp',
+  'ownedgames',
+  'mechShow',
+  'mechHide'
+]

--- a/components/v-actions.vue
+++ b/components/v-actions.vue
@@ -1,0 +1,72 @@
+<template>
+  <b-container class="actions" fluid>
+    <b-row>
+      <b-col sm="auto">
+        <b-button size="sm" variant="primary" v-clipboard="getShareLink()" @click="$toast.success('Link copied to clipboard', { icon : 'fa-clipboard'})">
+          <i class="fa fa-share-alt" aria-hidden="true"></i>
+          Share This List
+        </b-button>
+      </b-col>
+      <b-col sm="auto">
+        <b-button size="sm" variant="primary" @click="getARandomGame()">
+          <i class="fa fa-random" aria-hidden="true"></i>
+          Get Me A Game
+        </b-button>
+      </b-col>
+      <b-col sm="auto">
+        <b-button size="sm" variant="primary" @click="toggleListView()">
+          <span v-if="views.listView">
+            <i class="fa fa-th" aria-hidden="true"></i>
+            Toggle Grid View
+          </span>
+          <span v-if="!views.listView">
+            <i class="fa fa-list" aria-hidden="true"></i>
+            Toggle Table View
+          </span>
+        </b-button>
+      </b-col>
+    </b-row>
+  </b-container>
+</template>
+
+<script>
+
+import filterItems from '~/components/filterItems'
+import params from '~/components/params.js'
+
+export default {
+  data () {
+    return {
+      getShareLink: function () {
+        let link = `${window.location}?`
+        const { filters } = this.$store.state
+        const queryParams = params.map(param => (filters[param] ? `${param}=${filters[param]}` : null)).filter(i => !!i).join('&')
+        return encodeURI(`${link}${queryParams}`)
+      },
+      getARandomGame: function () {
+        const games = filterItems(this.$store.state.items[this.$route.name], this.$store.state.filters)
+        const ran = Math.floor(Math.random() * games.length)
+        this.$toast.success('Go play ' + games[ran].name, {
+          icon: 'fa-play',
+          action: {
+            text: 'Link',
+            href: 'https://boardgamegeek.com/boardgame/' + games[ran].id
+          }
+        })
+      },
+      views: this.$store.state.views
+    }
+  },
+  methods: {
+    toggleListView () {
+      this.$store.commit('views/toggleListView')
+    }
+  }
+}
+</script>
+
+<style>
+.actions {
+  margin-bottom: 1rem;
+}
+</style>

--- a/components/v-filters.vue
+++ b/components/v-filters.vue
@@ -1,0 +1,200 @@
+<template>
+  <b-container class="filters" fluid>
+    <b-row>
+      <b-col>
+        <b-btn v-b-toggle.collapse1 variant="outline-primary" size="sm">Toggle Filters</b-btn>
+      </b-col>
+    </b-row>
+    <b-collapse visible id="collapse1">
+      <b-form-group
+        horizontal
+        :label-cols="2"
+        label="Players">
+        <b-row>
+          <b-col sm="auto">
+            <b-form-input v-model="filters.bestnum" type="number" placeholder="Best #" min="1" size="sm" />
+          </b-col>
+          <b-col sm="auto">
+            <b-form-input v-model="filters.recnum" type="number" placeholder="Recommended #" min="1" size="sm" />
+          </b-col>
+          <b-col sm="auto">
+            <b-form-input v-model="filters.supplayer" type="number" placeholder="Supported #" min="1" size="sm" />
+          </b-col>
+        </b-row>
+      </b-form-group>
+      <b-form-group
+          horizontal
+          :label-cols="2"
+          label="Play Time">
+        <b-row>
+          <b-col sm="auto">
+            <b-form-input v-model="filters.mintime" type="number" placeholder="Min Play Time" min="0" step="10" size="sm" />
+          </b-col>
+          <b-col sm="auto">
+            <b-form-input v-model="filters.maxtime" type="number" placeholder="Max Play Time" min="0" step="10" size="sm" />
+          </b-col>
+        </b-row>
+      </b-form-group>
+      <b-form-group
+          horizontal
+          :label-cols="2"
+          label="Weight">
+        <b-row>
+          <b-col sm="auto">
+            <b-form-input v-model="filters.minweight" type="number" placeholder="Min Weight" min="1" step="0.1" size="sm" />
+          </b-col>
+            <b-col sm="auto">
+              <b-form-input v-model="filters.maxweight" type="number" placeholder="Max Weight" min="1" step="0.1" size="sm" />
+            </b-col>
+        </b-row>
+      </b-form-group>
+      <b-form-group
+          horizontal
+          :label-cols="2"
+          label="Plays">
+        <b-row>
+          <b-col sm="auto">
+            <b-form-input v-model="filters.playlessthan" type="number" placeholder="Fewer Than" min="0" size="sm" />
+          </b-col>
+        </b-row>
+      </b-form-group>
+      <b-row>
+        <b-col sm="auto">
+          <b-button size="sm" :id="'mech-filter'" variant="primary">
+            <i class="fa fa-gear" aria-hidden="true"></i>
+            Filter By Mechanisms
+          </b-button>
+          <b-popover :target="'mech-filter'"
+                     :placement="'bottom'"
+                     triggers="click"
+                     :show.sync="popoverShow"
+                     :content="`Placement`">
+            <b-tabs>
+              <b-tab title="Show" active>
+                <b-form-group>
+                  <b-form-checkbox-group v-model="mechShow" name="mechanisms" :options="mechOptions">
+                  </b-form-checkbox-group>
+                </b-form-group>
+              </b-tab>
+              <b-tab title="Hide">
+                <b-form-group>
+                  <b-form-checkbox-group v-model="mechHide" name="mechanisms" :options="mechOptions">
+                  </b-form-checkbox-group>
+                </b-form-group>
+              </b-tab>
+            </b-tabs>
+            <b-btn @click="onClose" size="sm" variant="primary">Close</b-btn>
+          </b-popover>
+        </b-col>
+        <b-col sm="auto" v-if="showOwned">
+          <b-button size="sm" variant="primary" @click="ownedgames = !ownedgames">
+            <span v-if="ownedgames">
+              <i class="fa fa-users" aria-hidden="true"></i>
+              Show All Games
+            </span>
+            <span v-if="!ownedgames">
+              <i class="fa fa-user" aria-hidden="true"></i>
+              Show Only Owned Games
+            </span>
+          </b-button>
+        </b-col>
+      </b-row>
+    </b-collapse>
+  </b-container>
+</template>
+
+<script>
+
+import { mapState } from 'vuex'
+import cookie from '~/components/cookie.js'
+import params from '~/components/params.js'
+const mechKeys = require('~/assets/mechKey.json')
+
+export default {
+  data () {
+    return {
+      mechOptions: this.getMechOptions(),
+      popoverShow: false
+    }
+  },
+  computed: {
+    ...mapState([
+      'filters'
+    ]),
+    _filters: function () {
+      return params.reduce((acc, val) => {
+        acc[val] = this[val]
+        return acc
+      }, {})
+    }
+  },
+  watch: {
+    _filters: function (filters) {
+      this.filters = filters
+      this.$store.commit('filters/set', filters)
+    }
+  },
+  methods: {
+    getMechOptions: function () {
+      return Object.keys(mechKeys).map(key => ({
+        text: mechKeys[key],
+        value: mechKeys[key]
+      }))
+    },
+    onClose () {
+      this.popoverShow = false
+    }
+  },
+  props: {
+    bestnum: {
+      type: Number
+    },
+    maxtime: {
+      type: Number
+    },
+    maxweight: {
+      type: Number
+    },
+    minweight: {
+      type: Number
+    },
+    mintime: {
+      type: Number
+    },
+    mechShow: {
+      default: () => [],
+      type: Array
+    },
+    mechHide: {
+      default: () => [],
+      type: Array
+    },
+    ownedgames: {
+      type: Boolean
+    },
+    playlessthan: {
+      type: Number
+    },
+    recnum: {
+      type: Number
+    },
+    showexp: {
+      default: !!cookie.get('showexp'),
+      type: Boolean
+    },
+    showOwned: {
+      type: Boolean
+    },
+    supplayer: {
+      type: Number
+    }
+  }
+}
+</script>
+
+<style>
+.filters.container-fluid {
+  text-align: left;
+  margin-bottom: .5rem;
+}
+</style>

--- a/components/v-grid.vue
+++ b/components/v-grid.vue
@@ -2,25 +2,27 @@
   <div class="header">
     <b-container class="bv-example-row">
       <b-row align-v="center">
-        <b-col v-for="item in orderedGames" :key="item.id">
+        <b-col v-for="item in filteredGames" :key="item.id">
           <a :href="'https://boardgamegeek.com/boardgame/' + item.id">
             <b-img width="100" rounded :src="item.imageUrl"/>
           </a>
         </b-col>
       </b-row>
     </b-container>
-    Item count: {{games.length}}
+    Item count: {{filteredGames.length}}
   </div>
 </template>
 
 <script>
-var _ = require('lodash')
+import filterItems from '~/components/filterItems.js'
+import _ from 'lodash'
 
 export default {
   computed: {
-    orderedGames: function () {
-      if (this.games.length) {
-        let temp = _.orderBy(this.games, [this.sortBy, 'average'], [this.asc ? 'asc' : 'desc', 'desc'])
+    filteredGames: function () {
+      let games = filterItems(this.games, this.$store.state.filters)
+      if (games.length) {
+        let temp = _.orderBy(games, [this.sortBy, 'average'], [this.asc ? 'asc' : 'desc', 'desc'])
         if (temp.length > 0 &&
             (!_.get(temp[0], 'rank') && _.get(temp[temp.length - 1], 'rank'))) {
           while (!_.get(temp[0], 'rank')) {
@@ -28,10 +30,10 @@ export default {
           }
         }
 
-        this.games = temp
+        games = temp
       }
 
-      return this.games
+      return games
     }
   },
   props: {

--- a/components/v-table.vue
+++ b/components/v-table.vue
@@ -12,7 +12,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr v-for="item in orderedGames" :key="item.id">
+        <tr v-for="item in filteredGames" :key="item.id">
           <td v-if="hasHeader('', true)">
             <a :href="'https://boardgamegeek.com/boardgame/' + item.id">
               <b-img width="75" :src="item.imageUrl"/>
@@ -61,28 +61,30 @@
         </tr>
       </tbody>
     </table>
-    Item count: {{games.length}}
+    Item count: {{filteredGames.length}}
   </div>
 </template>
 
 <script>
 import cookie from '~/components/cookie.js'
+import filterItems from '~/components/filterItems.js'
 var _ = require('lodash')
 
 export default {
   computed: {
-    orderedGames: function () {
-      if (this.games.length) {
-        let temp = _.orderBy(this.games, [this.sortBy, 'average'], [this.asc ? 'asc' : 'desc', 'desc'])
+    filteredGames: function () {
+      let games = filterItems(this.games, this.$store.state.filters)
+      if (games.length) {
+        let temp = _.orderBy(games, [this.sortBy, 'average'], [this.asc ? 'asc' : 'desc', 'desc'])
         if (temp.length > 0 &&
             (!_.get(temp[0], 'rank') && _.get(temp[temp.length - 1], 'rank'))) {
           while (!_.get(temp[0], 'rank')) {
             temp.push(temp.shift())
           }
         }
-        this.games = temp
+        games = temp
       }
-      return this.games
+      return games
     }
   },
   created: function () {
@@ -179,6 +181,7 @@ export default {
   },
   props: {
     defaultSort: {type: String},
+    extFilters: { type: Object },
     games: { type: Object },
     headers: { type: Array }
   }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -57,7 +57,7 @@ module.exports = {
       }),
       new webpack.DefinePlugin({
         'process.env': {
-          NODE_ENV: '"production"'
+          NODE_ENV: `"${process.env.NODE_ENV}"` || '"production"'
         }
       })
     ]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "junqdu@gmail.com",
   "private": true,
   "scripts": {
-    "dev": "nuxt",
+    "dev": "NODE_ENV=development nuxt",
     "build": "nuxt build",
     "start": "nuxt",
     "generate": "nuxt generate",

--- a/pages/help.vue
+++ b/pages/help.vue
@@ -26,6 +26,13 @@
     <h6>Best number of players filter:</h6>
     <input type="checkbox" id="best-at-least" v-model="bestatleast"> Show "At least" rather than exact, e.g. when input 3, rather showing game played best with 3, it will show 3 and above.
 
+    <h4>Clear cache</h4>
+    <b-input-group>
+      <b-input-group-button slot="left">
+        <b-btn @click="clear" variant="warning">Clear cache</b-btn>
+      </b-input-group-button>
+    </b-input-group>
+
     <h4>URL params</h4>
     <b-table striped hover :items="params"></b-table>
     <a href="https://en.wikipedia.org/wiki/Query_string#Structure">How to use URL params?</a>
@@ -51,6 +58,7 @@
 
 <script>
 import cookie from '~/components/cookie.js'
+import { mapActions } from 'vuex'
 
 export default {
   data () {
@@ -101,6 +109,9 @@ export default {
     }
   },
   methods: {
+    ...mapActions({
+      clear: 'items/cache/clear'
+    }),
     save: function () {
       cookie.set('username', this.userId)
       this.$toast.success('User ID updated', {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -60,13 +60,13 @@ export default {
     this.$store.commit('filters/reset', this.$route.query)
     this.$store.commit('filters/setOwned', true)
     const userIds = this.$route.query.userId || this.userId
-    this.fetch({ userIds, page: this.$route.name })
+    this.fetch({ userIds, page: 'index' })
   },
   computed: mapState({
-    items: state => state.items[this.$route.name],
-    loading: state => state.pageState[this.$route.name] ? !state.pageState[this.$route.name].loaded : true,
-    error: state => state.pageState[this.$route.name] ? state.pageState[this.$route.name].error : null,
-    errorMessage: state => state.pageState[this.$route.name] ? state.pageState[this.$route.name].errorMessage : null,
+    items: state => state.items['index'],
+    loading: state => state.pageState['index'] ? !state.pageState['index'].loaded : true,
+    error: state => state.pageState['index'] ? state.pageState['index'].error : null,
+    errorMessage: state => state.pageState['index'] ? state.pageState['index'].errorMessage : null,
     views: state => state.views
   }),
   data () {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -59,20 +59,18 @@ export default {
   created: function () {
     this.$store.commit('filters/reset', this.$route.query)
     this.$store.commit('filters/setOwned', true)
-    let userIds = this.$route.query.userId || this.userId
-    this.fetch(userIds)
+    const userIds = this.$route.query.userId || this.userId
+    this.fetch({ userIds, page: this.$route.name })
   },
   computed: mapState({
-    items: state => state.items['index'],
-    loading: state => state.pageState['index'] ? !state.pageState['index'].loaded : true,
-    error: state => state.pageState['index'] ? state.pageState['index'].error : null,
-    errorMessage: state => state.pageState['index'] ? state.pageState['index'].errorMessage : null
+    items: state => state.items[this.$route.name],
+    loading: state => state.pageState[this.$route.name] ? !state.pageState[this.$route.name].loaded : true,
+    error: state => state.pageState[this.$route.name] ? state.pageState[this.$route.name].error : null,
+    errorMessage: state => state.pageState[this.$route.name] ? state.pageState[this.$route.name].errorMessage : null,
+    views: state => state.views
   }),
   data () {
     return {
-      listView: true,
-      popoverShow: false,
-      views: this.$store.state.views,
       tableHeader: [
         {key: '', value: '', hide: this.$route.query.noimage},
         {key: 'rank', value: 'Rank'},
@@ -85,15 +83,13 @@ export default {
         {key: 'numplays', value: 'Plays'},
         {key: 'mech', value: 'Mechanisms'}
       ],
-      supplayer: this.$route.query.supplayer || undefined,
-      userId: cookie.get('username'),
-      waitingForBGG: false
+      userId: cookie.get('username')
     }
   },
   methods: {
     filteredItem: filterItems,
     ...mapActions({
-      fetch: 'items/query/fetch/index'
+      fetch: 'items/query/fetch'
     })
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,95 +1,36 @@
 <template>
   <section class="container">
     <div>
-      <v-loader v-if="loading"></v-loader>
-      <b-container v-if="!loading && !waitingForBGG" class="bv-example-row">
+      <v-loader v-if="loading && !error"></v-loader>
+      <b-container v-if="!loading && !error" class="bv-example-row">
         <b-row>
           <b-col>
-            <b-container class="filters" fluid>
-              <b-row>
-                  <b-col sm="auto"><input v-model="bestnum" type="number" placeholder="Best# of Players" min="1"></b-col>
-                  <b-col sm="auto"><input v-model="recnum" type="number" placeholder="Recom# of Players" min="1"></b-col>
-                  <b-col sm="auto"><input v-model="supplayer" type="number" placeholder="Support Players" min="1"></b-col>
-                  <b-col sm="auto"><input v-model="maxtime" type="number" placeholder="Max Play Time" min="0" step="10"></b-col>
-                  <b-col sm="auto"><input v-model="mintime" type="number" placeholder="Min Play Time" min="0" step="10"></b-col>
-                  <b-col sm="auto"><input v-model="maxweight" type="number" placeholder="Max Weight" min="1" step="0.1"></b-col>
-                  <b-col sm="auto"><input v-model="minweight" type="number" placeholder="Min Weight" min="1" step="0.1"></b-col>
-                  <b-col sm="auto"><input v-model="playlessthan" type="number" placeholder="Play Less Than" min="0"></b-col>
-                  <b-col sm="auto">
-                    <b-button size="sm" :id="'mech-filter'" variant="primary">
-                      <i class="fa fa-gear" aria-hidden="true"></i>
-                      Filter By Mechanisms
-                    </b-button>
-                    <b-popover :target="'mech-filter'"
-                               :placement="'bottom'"
-                               triggers="click"
-                               :show.sync="popoverShow"
-                               :content="`Placement ${placement}`">
-                      <b-tabs>
-                        <b-tab title="Show" active>
-                          <b-form-group>
-                            <b-form-checkbox-group v-model="mechShow" name="mechanisms" :options="mechOptions">
-                            </b-form-checkbox-group>
-                          </b-form-group>
-                        </b-tab>
-                        <b-tab title="Hide" >
-                          <b-form-group>
-                            <b-form-checkbox-group v-model="mechHide" name="mechanisms" :options="mechOptions">
-                            </b-form-checkbox-group>
-                          </b-form-group>
-                        </b-tab>
-                      </b-tabs>
-                      <b-btn @click="onClose" size="sm" variant="primary">Close</b-btn>
-                    </b-popover>
-                  </b-col>
-                  <b-col sm="auto">
-                    <b-button size="sm" variant="primary" v-clipboard="getShareLink()" @click="$toast.success('Link copied to clipboard', { icon : 'fa-clipboard'})">
-                      <i class="fa fa-share-alt" aria-hidden="true"></i>
-                      Share This List
-                    </b-button>
-                  </b-col>
-                  <b-col sm="auto">
-                    <b-button size="sm" variant="primary" @click="getARandomGame()">
-                      <i class="fa fa-random" aria-hidden="true"></i>
-                      Get Me A Game
-                    </b-button>
-                  </b-col>
-                  <b-col sm="auto">
-                    <b-button size="sm" variant="primary" @click="listView = !listView">
-                      <span v-if="listView">
-                        <i class="fa fa-th" aria-hidden="true"></i>
-                        Toggle Grid View
-                      </span>
-                      <span v-if="!listView">
-                        <i class="fa fa-list" aria-hidden="true"></i>
-                        Toggle Table View
-                      </span>
-                    </b-button>
-                  </b-col>
-              </b-row>
-            </b-container>
-            <v-table :games="filteredItem()" :headers="tableHeader" v-if="listView"></v-table>
-            <v-grid :games="filteredItem()" v-if="!listView"></v-grid>
+            <v-filters ownedgames></v-filters>
+            <v-actions></v-actions>
+          </b-col>
+        </b-row>
+        <b-row>
+          <b-col>
+            <v-table :games="items" :headers="tableHeader" v-if="views.listView"></v-table>
+            <v-grid :games="items" v-if="!views.listView"></v-grid>
           </b-col>
         </b-row>
       </b-container>
-      <v-refresh v-if="waitingForBGG" :message="errorMessage"></v-refresh>
+      <v-refresh v-if="error" :message="errorMessage"></v-refresh>
     </div>
   </section>
 </template>
 
 <script>
-import axios from 'axios'
 import cookie from '~/components/cookie.js'
-import Game from '~/components/Game.js'
+import filterItems from '~/components/filterItems.js'
+import VFilters from '~/components/v-filters.vue'
+import VActions from '~/components/v-actions.vue'
 import VGrid from '~/components/v-grid.vue'
 import VLoader from '~/components/v-loader.vue'
 import VRefresh from '~/components/v-refresh.vue'
 import VTable from '~/components/v-table.vue'
-import X2JS from 'x2js'
-
-var _ = require('lodash')
-const keys = require('../assets/mechKey.json')
+import { mapActions, mapState } from 'vuex'
 
 export default {
   beforeCreate: function () {
@@ -111,104 +52,27 @@ export default {
     VGrid,
     VLoader,
     VRefresh,
-    VTable
+    VTable,
+    VActions,
+    VFilters
   },
   created: function () {
+    this.$store.commit('filters/reset', this.$route.query)
+    this.$store.commit('filters/setOwned', true)
     let userIds = this.$route.query.userId || this.userId
-    userIds = userIds.split(',').slice(0, 9)
-    const promises = []
-
-    _.forEach(userIds, (userId) => {
-      if (userId) {
-        promises.push(axios.get('https://www.boardgamegeek.com/xmlapi2/collection', {
-          params: {
-            stats: 1,
-            username: userId.trim()
-          }
-        }))
-      }
-    })
-
-    axios.all(promises).then((results) => {
-      var items = {}
-      this.loading = false
-      var x2js = new X2JS()
-
-      _.forEach(results, (result) => {
-        var data = x2js.xml2js(result.data)
-        this.games.push(data)
-
-        let userId = _.get(result, 'config.params.username')
-
-        let rank
-        _.forEach(_.get(data, 'items.item'), item => {
-          if (_.get(item, 'stats.rating.ranks.rank.length', false)) {
-            rank = parseFloat(item.stats.rating.ranks.rank[0]._value)
-          } else {
-            rank = parseFloat(_.get(item, 'stats.rating.ranks.rank._value'))
-          }
-
-          let gameId = item._objectid
-          let numplays = parseFloat(item.numplays)
-          let rating = parseFloat(item.stats.rating._value)
-          if (items[gameId]) {
-            items[gameId].users[userId] = {
-              numplays,
-              rating: rating || 0
-            }
-            items[gameId].numplays += numplays || 0
-            items[gameId].rating = this.getAverageRating(items[gameId].users)
-            if (!items[gameId].own) {
-              items[gameId].own = _.get(item, 'status._own') === '1'
-            }
-          } else {
-            items[gameId] = (new Game({
-              average: parseFloat(_.get(item, 'stats.rating.average._value')),
-              id: gameId,
-              imageUrl: item.thumbnail,
-              maxplayer: parseFloat(item.stats._maxplayers),
-              minplayer: parseFloat(item.stats._minplayers),
-              name: item.name.__text,
-              numplays,
-              own: _.get(item, 'status._own') === '1',
-              playingtime: parseFloat(item.stats._playingtime),
-              rank,
-              rating,
-              userId
-            }))
-          }
-        })
-      })
-
-      this.items = items
-    }).catch((res) => {
-      if (res.config) {
-        this.errorMessage = `Waiting for BGG to process for user "${res.config.params.username}". Please try again later for access.`
-      } else {
-        this.errorMessage = res.message
-      }
-      this.loading = false
-      this.waitingForBGG = true
-    })
+    this.fetch(userIds)
   },
+  computed: mapState({
+    items: state => state.items['index'],
+    loading: state => state.pageState['index'] ? !state.pageState['index'].loaded : true,
+    error: state => state.pageState['index'] ? state.pageState['index'].error : null,
+    errorMessage: state => state.pageState['index'] ? state.pageState['index'].errorMessage : null
+  }),
   data () {
     return {
-      bestnum: this.$route.query.bestnum || undefined,
-      errorMessage: '',
-      games: [],
-      items: {},
       listView: true,
-      loading: true,
-      maxtime: this.$route.query.maxtime || undefined,
-      maxweight: this.$route.query.maxweight || undefined,
-      mechOptions: this.getMechOptions(),
-      mechHide: [],
-      mechShow: [],
-      mintime: this.$route.query.mintime || undefined,
-      minweight: this.$route.query.minweight || undefined,
-      playlessthan: this.$route.query.playlessthan || undefined,
       popoverShow: false,
-      recnum: this.$route.query.recnum || undefined,
+      views: this.$store.state.views,
       tableHeader: [
         {key: '', value: '', hide: this.$route.query.noimage},
         {key: 'rank', value: 'Rank'},
@@ -227,88 +91,10 @@ export default {
     }
   },
   methods: {
-    filteredItem: function () {
-      return _.filter(this.items, (item) => {
-        let bestnum = false
-        if (cookie.get('bestatleast')) {
-          const highestNum = _.get(item, 'bggbestplayers', '').split(',').pop()
-          if (highestNum) {
-            bestnum = +highestNum >= this.bestnum
-          }
-        } else {
-          bestnum = _.get(item, 'bggbestplayers', '').split(',').includes(this.bestnum)
-        }
-
-        let mech = true
-
-        if (this.mechShow.length > 0) {
-          mech = _.intersection(this.mechShow, item.mech).length === this.mechShow.length
-        }
-
-        if (this.mechHide.length > 0 && mech) {
-          mech = !_.intersection(this.mechHide, item.mech).length > 0
-        }
-
-        return (!this.bestnum || bestnum) &&
-        (!this.recnum || _.get(item, 'bggrecplayers', '').split(',').includes(this.recnum)) &&
-        (!this.mintime || item.playingtime >= this.mintime) &&
-        (!this.maxtime || item.playingtime <= this.maxtime) &&
-        (!this.supplayer || (item.minplayer <= this.supplayer && item.maxplayer >= this.supplayer)) &&
-        (!this.maxweight || item.weight <= this.maxweight) &&
-        (!this.minweight || item.weight >= this.minweight) &&
-        ((cookie.get('showexp') === 'false' && item.type !== 'e') || cookie.get('showexp') === 'true') &&
-        ((cookie.get('showexp') === 'true' && item.type === 'e' && item.average >= cookie.get('expmin')) || item.type !== 'e') &&
-        (!this.playlessthan || item.numplays <= this.playlessthan) &&
-        item.own && mech
-      })
-    },
-    getAverageRating: function (users) {
-      let sum = 0
-      let count = 0
-      _.forEach(users, user => {
-        if (user.rating) {
-          sum += user.rating
-          count++
-        }
-      })
-      let avg = sum / count
-      return avg || 0
-    },
-    getARandomGame: function () {
-      const games = this.filteredItem()
-      const ran = Math.floor(Math.random() * games.length)
-      this.$toast.success('Go play ' + games[ran].name, {
-        icon: 'fa-play',
-        action: {
-          text: 'Link',
-          href: 'https://boardgamegeek.com/boardgame/' + games[ran].id
-        }
-      })
-    },
-    getMechOptions: function () {
-      const temp = []
-      _.forEach(keys, function (key) {
-        temp.push({text: key, value: key})
-      })
-      return temp
-    },
-    getShareLink: function () {
-      let link = 'https://gameshelf.github.io?'
-      const params = ['userId', 'bestnum', 'maxtime', 'maxweight', 'mintime', 'minweight', 'recnum', 'supplayer', 'playlessthan']
-      _.forEach(params, param => {
-        if (this[param]) {
-          link = link + param + '=' + this[param] + '&'
-        }
-      })
-      link = link.slice(0, link.length - 1)
-      if (cookie.get('showexp') === 'true') {
-        link = link + 'showexp' + '=' + cookie.get('showexp')
-      }
-      return encodeURI(link)
-    },
-    onClose () {
-      this.popoverShow = false
-    }
+    filteredItem: filterItems,
+    ...mapActions({
+      fetch: 'items/query/fetch/index'
+    })
   }
 }
 </script>

--- a/pages/trade-sale.vue
+++ b/pages/trade-sale.vue
@@ -1,71 +1,35 @@
 <template>
   <section class="container">
     <div>
-      <v-loader v-if="loading"></v-loader>
-      <b-container v-if="!loading && !waitingForBGG" class="bv-example-row">
+      <v-loader v-if="loading && !error"></v-loader>
+      <b-container v-if="!loading && !error" class="bv-example-row">
         <b-row>
           <b-col>
-            <b-container class="filters" fluid>
-              <b-row>
-                  <b-col sm="auto"><input v-model="bestnum" type="number" placeholder="Best# of Players" min="1"></b-col>
-                  <b-col sm="auto"><input v-model="recnum" type="number" placeholder="Recom# of Players" min="1"></b-col>
-                  <b-col sm="auto"><input v-model="supplayer" type="number" placeholder="Support Players" min="1"></b-col>
-                  <b-col sm="auto"><input v-model="maxtime" type="number" placeholder="Max Play Time" min="0" step="10"></b-col>
-                  <b-col sm="auto"><input v-model="mintime" type="number" placeholder="Min Play Time" min="0" step="10"></b-col>
-                  <b-col sm="auto"><input v-model="maxweight" type="number" placeholder="Max Weight" min="1" step="0.1"></b-col>
-                  <b-col sm="auto"><input v-model="minweight" type="number" placeholder="Min Weight" min="1" step="0.1"></b-col>
-                  <b-col sm="auto">
-                    <b-button size="sm" variant="primary" v-clipboard="getShareLink()" @click="$toast.success('Link copied to clipboard', { icon : 'fa-clipboard'})">
-                      <i class="fa fa-share-alt" aria-hidden="true"></i>
-                      Link For This List
-                    </b-button>
-                  </b-col>
-                  <b-col sm="auto">
-                    <b-button size="sm" variant="primary" v-clipboard="getText()" @click="$toast.success('Copied as text', { icon : 'fa-clipboard'})">
-                      <i class="fa fa-clipboard" aria-hidden="true"></i>
-                      Copy As Text
-                    </b-button>
-                  </b-col>
-                  <b-col sm="auto">
-                    <b-button size="sm" variant="primary" @click="getARandomGame()">
-                      <i class="fa fa-random" aria-hidden="true"></i>
-                      Get Me A Game
-                    </b-button>
-                  </b-col>
-                  <b-col sm="auto">
-                    <b-button size="sm" variant="primary" @click="listView = !listView">
-                      <span v-if="listView">
-                        <i class="fa fa-th" aria-hidden="true"></i>
-                        Toggle Grid View
-                      </span>
-                      <span v-if="!listView">
-                        <i class="fa fa-list" aria-hidden="true"></i>
-                        Toggle Table View
-                      </span>
-                    </b-button>
-                  </b-col>
-              </b-row>
-            </b-container>
-            <v-table :games="filteredItem()" :headers="tableHeader" v-if="listView"></v-table>
-            <v-grid :games="filteredItem()" v-if="!listView"></v-grid>
+            <v-filters showOwned></v-filters>
+            <v-actions></v-actions>
+          </b-col>
+        </b-row>
+        <b-row>
+          <b-col>
+            <v-table :games="items" :headers="tableHeader" v-if="views.listView"></v-table>
+            <v-grid :games="items" v-if="!views.listView"></v-grid>
           </b-col>
         </b-row>
       </b-container>
-      <v-refresh :message="errorMessage" v-if="waitingForBGG"></v-refresh>
+      <v-refresh v-if="error" :message="errorMessage"></v-refresh>
     </div>
   </section>
 </template>
 
 <script>
-import axios from 'axios'
 import cookie from '~/components/cookie.js'
-import Game from '~/components/Game.js'
 import VGrid from '~/components/v-grid.vue'
 import VRefresh from '~/components/v-refresh.vue'
 import VLoader from '~/components/v-loader.vue'
 import VTable from '~/components/v-table.vue'
-import X2JS from 'x2js'
-var _ = require('lodash')
+import VFilters from '~/components/v-filters.vue'
+import VActions from '~/components/v-actions.vue'
+import { mapActions, mapState } from 'vuex'
 
 export default {
   beforeCreate: function () {
@@ -81,69 +45,23 @@ export default {
     VGrid,
     VLoader,
     VRefresh,
-    VTable
+    VTable,
+    VFilters,
+    VActions
   },
   created: function () {
-    let userIds = this.$route.query.userId || this.userId
-    userIds = userIds.split(',').slice(0, 9)
-    return axios.get('https://www.boardgamegeek.com/xmlapi2/collection', {
-      params: {
-        stats: 1,
-        trade: 1,
-        own: 1,
-        username: userIds[0].trim()
-      }
-    })
-      .then((res) => {
-        this.loading = false
-        if (res.status === 200) {
-          var x2js = new X2JS()
-          var data = x2js.xml2js(res.data)
-
-          var items = []
-          let rank
-          _.forEach(_.get(data, 'items.item'), function (item) {
-            if (item.stats.rating.ranks.rank.length) {
-              rank = parseFloat(item.stats.rating.ranks.rank[0]._value)
-            } else {
-              rank = parseFloat(item.stats.rating.ranks.rank._value)
-            }
-            items.push(new Game({
-              average: parseFloat(item.stats.rating.average._value),
-              comment: item.comment,
-              id: item._objectid,
-              imageUrl: item.thumbnail,
-              maxplayer: parseFloat(item.stats._maxplayers),
-              minplayer: parseFloat(item.stats._minplayers),
-              name: item.name.__text,
-              numplays: parseFloat(item.numplays),
-              playingtime: parseFloat(item.stats._playingtime),
-              rank,
-              rating: parseFloat(item.stats.rating._value)
-            }))
-          })
-          this.items = items
-        }
-      })
-      .catch((res) => {
-        console.log(res)
-        this.errorMessage = `Waiting for BGG to process for user "${res.config.params.username}". Please try again later for access.`
-        this.loading = false
-        this.waitingForBGG = true
-      })
+    const userIds = this.$route.query.userId || this.userId
+    this.fetch({ userIds, page: 'trade-sale', own: 1, trade: 1 })
   },
+  computed: mapState({
+    items: state => state.items['trade-sale'],
+    loading: state => state.pageState['trade-sale'] ? !state.pageState['trade-sale'].loaded : true,
+    error: state => state.pageState['trade-sale'] ? state.pageState['trade-sale'].error : null,
+    errorMessage: state => state.pageState['trade-sale'] ? state.pageState['trade-sale'].errorMessage : null,
+    views: state => state.views
+  }),
   data () {
     return {
-      bestnum: this.$route.query.bestnum || undefined,
-      errorMessage: '',
-      items: [],
-      listView: true,
-      loading: true,
-      maxtime: this.$route.query.maxtime || undefined,
-      maxweight: this.$route.query.maxweight || undefined,
-      mintime: this.$route.query.mintime || undefined,
-      minweight: this.$route.query.minweight || undefined,
-      recnum: this.$route.query.recnum || undefined,
       tableHeader: [
         {key: '', value: '', hide: this.$route.query.noimage},
         {key: 'rank', value: 'Rank'},
@@ -154,66 +72,13 @@ export default {
         {key: 'bggbestplayers', value: 'Best #Player'},
         {key: 'comment', value: 'Comment'}
       ],
-      supplayer: this.$route.query.supplayer || undefined,
-      userId: cookie.get('username'),
-      waitingForBGG: false
+      userId: cookie.get('username')
     }
   },
   methods: {
-    getARandomGame: function () {
-      const games = this.filteredItem()
-      const ran = Math.floor(Math.random() * games.length)
-      this.$toast.success('Go play ' + games[ran].name, {
-        icon: 'fa-play',
-        action: {
-          text: 'Link',
-          href: 'https://boardgamegeek.com/boardgame/' + games[ran].id
-        }
-      })
-    },
-    getText: function () {
-      let result = ''
-      let games = this.filteredItem()
-      games = _.sortBy(games, ['name'])
-      _.forEach(games, function (game) {
-        result += game.name + ' - ' + (game.comment || '') + '\n'
-      })
-      return result
-    },
-    getShareLink: function () {
-      let link = 'https://gameshelf.github.io/trade-sale?'
-      const params = ['userId', 'bestnum', 'maxtime', 'maxweight', 'mintime', 'minweight', 'recnum', 'supplayer']
-      _.forEach(params, param => {
-        if (this[param]) {
-          link = link + param + '=' + this[param] + '&'
-        }
-      })
-      link = link.slice(0, link.length - 1)
-      if (cookie.get('showexp') === 'true') {
-        link = link + 'showexp' + '=' + cookie.get('showexp')
-      }
-      return encodeURI(link)
-    },
-    filteredItem: function () {
-      return this.items.filter((item) => {
-        let bestnum = false
-        if (cookie.get('bestatleast')) {
-          const highestNum = _.get(item, 'bggbestplayers', '').split(',').pop()
-          if (highestNum) {
-            bestnum = +highestNum >= this.bestnum
-          }
-        } else {
-          bestnum = _.get(item, 'bggbestplayers', '').split(',').includes(this.bestnum)
-        }
-        return (!this.bestnum || bestnum) &&
-        (!this.recnum || _.get(item, 'bggrecplayers', '').split(',').includes(this.recnum)) &&
-        (!this.mintime || item.playingtime >= this.mintime) &&
-        (!this.maxtime || item.playingtime <= this.maxtime) &&
-        (!this.supplayer || (item.minplayer <= this.supplayer && item.maxplayer >= this.supplayer)) &&
-        (!this.maxweight || item.weight <= this.maxweight) &&
-        (!this.minweight || item.weight >= this.minweight)
-      })
-    }
+    ...mapActions({
+      fetch: 'items/query/fetch'
+    })
   }
 }
 </script>

--- a/pages/want-to-play.vue
+++ b/pages/want-to-play.vue
@@ -1,8 +1,8 @@
 <template>
   <section class="container">
     <div>
-      <v-loader v-if="loading"></v-loader>
-      <b-container v-if="!loading && !waitingForBGG" class="bv-example-row">
+      <v-loader v-if="loading && !error"></v-loader>
+      <b-container v-if="!loading && !error" class="bv-example-row">
         <b-row>
           <b-col>
             <v-filters showOwned></v-filters>
@@ -16,23 +16,20 @@
           </b-col>
         </b-row>
       </b-container>
-      <v-refresh :message="errorMessage" v-if="waitingForBGG"></v-refresh>
+      <v-refresh v-if="error" :message="errorMessage"></v-refresh>
     </div>
   </section>
 </template>
 
 <script>
-import axios from 'axios'
 import cookie from '~/components/cookie.js'
-import Game from '~/components/Game.js'
 import VGrid from '~/components/v-grid.vue'
 import VRefresh from '~/components/v-refresh.vue'
 import VLoader from '~/components/v-loader.vue'
 import VTable from '~/components/v-table.vue'
 import VFilters from '~/components/v-filters.vue'
 import VActions from '~/components/v-actions.vue'
-import X2JS from 'x2js'
-var _ = require('lodash')
+import { mapActions, mapState } from 'vuex'
 
 export default {
   beforeCreate: function () {
@@ -52,62 +49,31 @@ export default {
     VFilters,
     VActions
   },
+  methods: {
+    ...mapActions({
+      fetch: 'items/query/fetch'
+    })
+  },
   created: function () {
     this.$store.commit('filters/reset')
     this.$store.commit('filters/setOwned', false)
-    let userIds = this.$route.query.userId || this.userId
-    userIds = userIds.split(',').slice(0, 9)
-    return axios.get('https://www.boardgamegeek.com/xmlapi2/collection', {
-      params: {
-        stats: 1,
-        username: userIds[0].trim(),
-        wanttoplay: 1
-      }
+    const userIds = this.$route.query.userId || this.userId
+    this.fetch({
+      userIds,
+      page: 'want-to-play',
+      wantToPlay: 1
     })
-      .then((res) => {
-        this.loading = false
-        if (res.status === 200) {
-          var x2js = new X2JS()
-          var data = x2js.xml2js(res.data)
-
-          var items = []
-          let rank
-          _.forEach(_.get(data, 'items.item'), function (item) {
-            if (item.stats.rating.ranks.rank.length) {
-              rank = parseFloat(item.stats.rating.ranks.rank[0]._value)
-            } else {
-              rank = parseFloat(item.stats.rating.ranks.rank._value)
-            }
-            items.push(new Game({
-              average: parseFloat(item.stats.rating.average._value),
-              id: item._objectid,
-              imageUrl: item.thumbnail,
-              maxplayer: parseFloat(item.stats._maxplayers),
-              minplayer: parseFloat(item.stats._minplayers),
-              name: item.name.__text,
-              numplays: parseFloat(item.numplays),
-              own: _.get(item, 'status._own') === '1',
-              playingtime: parseFloat(item.stats._playingtime),
-              rank,
-              rating: parseFloat(item.stats.rating._value)
-            }))
-          })
-          this.items = items
-        }
-      })
-      .catch((res) => {
-        console.log(res)
-        this.errorMessage = `Waiting for BGG to process for user "${res.config.params.username}". Please try again later for access.`
-        this.loading = false
-        this.waitingForBGG = true
-      })
   },
+  computed: mapState({
+    items: state => state.items['want-to-play'],
+    loading: state => state.pageState['want-to-play'] ? !state.pageState['want-to-play'].loaded : true,
+    error: state => state.pageState['want-to-play'] ? state.pageState['want-to-play'].error : null,
+    errorMessage: state => state.pageState['want-to-play'] ? state.pageState['want-to-play'].errorMessage : null,
+    views: state => state.views
+  }),
   data () {
     return {
-      errorMessage: '',
       filters: {},
-      items: [],
-      loading: true,
       tableHeader: [
         {key: '', value: '', hide: this.$route.query.noimage},
         {key: 'rank', value: 'Rank'},
@@ -118,9 +84,7 @@ export default {
         {key: 'bggbestplayers', value: 'Best #Player'},
         {key: 'mech', value: 'Mechanisms'}
       ],
-      views: this.$store.state.views,
-      userId: cookie.get('username'),
-      waitingForBGG: false
+      userId: cookie.get('username')
     }
   }
 }

--- a/pages/wishlist.vue
+++ b/pages/wishlist.vue
@@ -5,49 +5,10 @@
       <b-container v-if="!loading && !waitingForBGG" class="bv-example-row">
         <b-row>
           <b-col>
-            <b-container class="filters" fluid>
-              <b-row>
-                  <b-col sm="auto"><input v-model="bestnum" type="number" placeholder="Best# of Players" min="1"></b-col>
-                  <b-col sm="auto"><input v-model="recnum" type="number" placeholder="Recom# of Players" min="1"></b-col>
-                  <b-col sm="auto"><input v-model="supplayer" type="number" placeholder="Support Players" min="1"></b-col>
-                  <b-col sm="auto"><input v-model="maxtime" type="number" placeholder="Max Play Time" min="0" step="10"></b-col>
-                  <b-col sm="auto"><input v-model="mintime" type="number" placeholder="Min Play Time" min="0" step="10"></b-col>
-                  <b-col sm="auto"><input v-model="maxweight" type="number" placeholder="Max Weight" min="1" step="0.1"></b-col>
-                  <b-col sm="auto"><input v-model="minweight" type="number" placeholder="Min Weight" min="1" step="0.1"></b-col>
-                  <b-col sm="auto">
-                    <b-button size="sm" variant="primary" v-clipboard="getShareLink()" @click="$toast.success('Link copied to clipboard', { icon : 'fa-clipboard'})">
-                      <i class="fa fa-share-alt" aria-hidden="true"></i>
-                      Share This List
-                    </b-button>
-                  </b-col>
-                  <b-col sm="auto">
-                    <b-button size="sm" variant="primary" v-clipboard="getText()" @click="$toast.success('Copied as text', { icon : 'fa-clipboard'})">
-                      <i class="fa fa-clipboard" aria-hidden="true"></i>
-                      Copy As Text
-                    </b-button>
-                  </b-col>
-                  <b-col sm="auto">
-                    <b-button size="sm" variant="primary" @click="getARandomGame()">
-                      <i class="fa fa-random" aria-hidden="true"></i>
-                      Get Me A Game
-                    </b-button>
-                  </b-col>
-                  <b-col sm="auto">
-                    <b-button size="sm" variant="primary" @click="listView = !listView">
-                      <span v-if="listView">
-                        <i class="fa fa-th" aria-hidden="true"></i>
-                        Toggle Grid View
-                      </span>
-                      <span v-if="!listView">
-                        <i class="fa fa-list" aria-hidden="true"></i>
-                        Toggle Table View
-                      </span>
-                    </b-button>
-                  </b-col>
-              </b-row>
-            </b-container>
-            <v-table :games="filteredItem()" :default-sort="'wishlistpriority'" :headers="tableHeader" v-if="listView"></v-table>
-            <v-grid :games="filteredItem()" v-if="!listView"></v-grid>
+            <v-filters></v-filters>
+            <v-actions></v-actions>
+            <v-table :games="items" :default-sort="'wishlistpriority'" :headers="tableHeader" v-if="views.listView"></v-table>
+            <v-grid :games="items" v-if="!views.listView"></v-grid>
           </b-col>
         </b-row>
       </b-container>
@@ -64,6 +25,8 @@ import VGrid from '~/components/v-grid.vue'
 import VRefresh from '~/components/v-refresh.vue'
 import VLoader from '~/components/v-loader.vue'
 import VTable from '~/components/v-table.vue'
+import VFilters from '~/components/v-filters.vue'
+import VActions from '~/components/v-actions.vue'
 import X2JS from 'x2js'
 var _ = require('lodash')
 
@@ -81,9 +44,12 @@ export default {
     VGrid,
     VLoader,
     VRefresh,
-    VTable
+    VTable,
+    VFilters,
+    VActions
   },
   created: function () {
+    this.$store.commit('filters/setOwned', false)
     let userIds = this.$route.query.userId || this.userId
     userIds = userIds.split(',').slice(0, 9)
     return axios.get('https://www.boardgamegeek.com/xmlapi2/collection', {
@@ -133,16 +99,10 @@ export default {
   },
   data () {
     return {
-      bestnum: this.$route.query.bestnum || undefined,
       errorMessage: '',
       items: [],
       listView: true,
       loading: true,
-      maxtime: this.$route.query.maxtime || undefined,
-      maxweight: this.$route.query.maxweight || undefined,
-      mintime: this.$route.query.mintime || undefined,
-      minweight: this.$route.query.minweight || undefined,
-      recnum: this.$route.query.recnum || undefined,
       tableHeader: [
         {key: '', value: '', hide: this.$route.query.noimage},
         {key: 'rank', value: 'Rank'},
@@ -153,8 +113,8 @@ export default {
         {key: 'bggbestplayers', value: 'Best #Player'},
         {key: 'wishlistpriority', value: 'Priority'}
       ],
-      supplayer: this.$route.query.supplayer || undefined,
       userId: cookie.get('username'),
+      views: this.$store.state.views,
       waitingForBGG: false
     }
   },
@@ -168,49 +128,6 @@ export default {
           text: 'Link',
           href: 'https://boardgamegeek.com/boardgame/' + games[ran].id
         }
-      })
-    },
-    getText: function () {
-      let result = ''
-      let games = this.filteredItem()
-      games = _.sortBy(games, ['name'])
-      _.forEach(games, function (game) {
-        result += game.name + '\n'
-      })
-      return result
-    },
-    getShareLink: function () {
-      let link = 'https://gameshelf.github.io/wishlist?'
-      const params = ['userId', 'bestnum', 'maxtime', 'maxweight', 'mintime', 'minweight', 'recnum', 'supplayer']
-      _.forEach(params, param => {
-        if (this[param]) {
-          link = link + param + '=' + this[param] + '&'
-        }
-      })
-      link = link.slice(0, link.length - 1)
-      if (cookie.get('showexp') === 'true') {
-        link = link + 'showexp' + '=' + cookie.get('showexp')
-      }
-      return encodeURI(link)
-    },
-    filteredItem: function () {
-      return this.items.filter((item) => {
-        let bestnum = false
-        if (cookie.get('bestatleast')) {
-          const highestNum = _.get(item, 'bggbestplayers', '').split(',').pop()
-          if (highestNum) {
-            bestnum = +highestNum >= this.bestnum
-          }
-        } else {
-          bestnum = _.get(item, 'bggbestplayers', '').split(',').includes(this.bestnum)
-        }
-        return (!this.bestnum || bestnum) &&
-        (!this.recnum || _.get(item, 'bggrecplayers', '').split(',').includes(this.recnum)) &&
-        (!this.mintime || item.playingtime >= this.mintime) &&
-        (!this.maxtime || item.playingtime <= this.maxtime) &&
-        (!this.supplayer || (item.minplayer <= this.supplayer && item.maxplayer >= this.supplayer)) &&
-        (!this.maxweight || item.weight <= this.maxweight) &&
-        (!this.minweight || item.weight >= this.minweight)
       })
     }
   }

--- a/pages/wishlist.vue
+++ b/pages/wishlist.vue
@@ -25,7 +25,6 @@ import VLoader from '~/components/v-loader.vue'
 import VTable from '~/components/v-table.vue'
 import VFilters from '~/components/v-filters.vue'
 import VActions from '~/components/v-actions.vue'
-import filterItems from '~/components/filterItems.js'
 import { mapActions, mapState } from 'vuex'
 
 export default {
@@ -46,12 +45,9 @@ export default {
     VFilters,
     VActions
   },
-  methods: {
-    filteredItem: filterItems,
-    ...mapActions({
-      fetch: 'items/query/fetch'
-    })
-  },
+  methods: mapActions({
+    fetch: 'items/query/fetch'
+  }),
   computed: mapState({
     items: state => state.items['wishlist'],
     loading: state => state.pageState['wishlist'] ? !state.pageState['wishlist'].loaded : true,

--- a/pages/wishlist.vue
+++ b/pages/wishlist.vue
@@ -1,8 +1,8 @@
 <template>
   <section class="container">
     <div>
-      <v-loader v-if="loading"></v-loader>
-      <b-container v-if="!loading && !waitingForBGG" class="bv-example-row">
+      <v-loader v-if="loading && !error"></v-loader>
+      <b-container v-if="!loading && !error" class="bv-example-row">
         <b-row>
           <b-col>
             <v-filters></v-filters>
@@ -12,23 +12,21 @@
           </b-col>
         </b-row>
       </b-container>
-      <v-refresh :message="errorMessage" v-if="waitingForBGG"></v-refresh>
+      <v-refresh v-if="error" :message="errorMessage"></v-refresh>
     </div>
   </section>
 </template>
 
 <script>
-import axios from 'axios'
 import cookie from '~/components/cookie.js'
-import Game from '~/components/Game.js'
 import VGrid from '~/components/v-grid.vue'
 import VRefresh from '~/components/v-refresh.vue'
 import VLoader from '~/components/v-loader.vue'
 import VTable from '~/components/v-table.vue'
 import VFilters from '~/components/v-filters.vue'
 import VActions from '~/components/v-actions.vue'
-import X2JS from 'x2js'
-var _ = require('lodash')
+import filterItems from '~/components/filterItems.js'
+import { mapActions, mapState } from 'vuex'
 
 export default {
   beforeCreate: function () {
@@ -48,61 +46,27 @@ export default {
     VFilters,
     VActions
   },
+  methods: {
+    filteredItem: filterItems,
+    ...mapActions({
+      fetch: 'items/query/fetch'
+    })
+  },
+  computed: mapState({
+    items: state => state.items['wishlist'],
+    loading: state => state.pageState['wishlist'] ? !state.pageState['wishlist'].loaded : true,
+    error: state => state.pageState['wishlist'] ? state.pageState['wishlist'].error : null,
+    errorMessage: state => state.pageState['wishlist'] ? state.pageState['wishlist'].errorMessage : null,
+    views: state => state.views
+  }),
   created: function () {
     this.$store.commit('filters/setOwned', false)
-    let userIds = this.$route.query.userId || this.userId
-    userIds = userIds.split(',').slice(0, 9)
-    return axios.get('https://www.boardgamegeek.com/xmlapi2/collection', {
-      params: {
-        stats: 1,
-        username: userIds[0].trim(),
-        wishlist: 1
-      }
-    })
-      .then((res) => {
-        this.loading = false
-        if (res.status === 200) {
-          var x2js = new X2JS()
-          var data = x2js.xml2js(res.data)
-
-          var items = []
-          let rank
-          _.forEach(_.get(data, 'items.item'), function (item) {
-            if (item.stats.rating.ranks.rank.length) {
-              rank = parseFloat(item.stats.rating.ranks.rank[0]._value)
-            } else {
-              rank = parseFloat(item.stats.rating.ranks.rank._value)
-            }
-            items.push(new Game({
-              average: parseFloat(item.stats.rating.average._value),
-              id: item._objectid,
-              imageUrl: item.thumbnail,
-              maxplayer: parseFloat(item.stats._maxplayers),
-              minplayer: parseFloat(item.stats._minplayers),
-              name: item.name.__text,
-              numplays: parseFloat(item.numplays),
-              playingtime: parseFloat(item.stats._playingtime),
-              rank,
-              rating: parseFloat(item.stats.rating._value),
-              wishlistpriority: item.status._wishlistpriority
-            }))
-          })
-          this.items = items
-        }
-      })
-      .catch((res) => {
-        console.log(res)
-        this.errorMessage = `Waiting for BGG to process for user "${res.config.params.username}". Please try again later for access.`
-        this.loading = false
-        this.waitingForBGG = true
-      })
+    const userIds = this.$route.query.userId || this.userId
+    this.fetch({ userIds, page: 'wishlist', own: 0, wishlist: 1 })
   },
   data () {
     return {
-      errorMessage: '',
-      items: [],
       listView: true,
-      loading: true,
       tableHeader: [
         {key: '', value: '', hide: this.$route.query.noimage},
         {key: 'rank', value: 'Rank'},
@@ -114,21 +78,7 @@ export default {
         {key: 'wishlistpriority', value: 'Priority'}
       ],
       userId: cookie.get('username'),
-      views: this.$store.state.views,
       waitingForBGG: false
-    }
-  },
-  methods: {
-    getARandomGame: function () {
-      const games = this.filteredItem()
-      const ran = Math.floor(Math.random() * games.length)
-      this.$toast.success('Go play ' + games[ran].name, {
-        icon: 'fa-play',
-        action: {
-          text: 'Link',
-          href: 'https://boardgamegeek.com/boardgame/' + games[ran].id
-        }
-      })
     }
   }
 }

--- a/store/index.js
+++ b/store/index.js
@@ -112,6 +112,9 @@ const createStore = () => {
         if (collections) {
           commit('items/query/done', { key: page, val: combineCollections(collections) })
         }
+      },
+      'items/cache/clear': () => {
+        localStorage.clear(/^collection/)
       }
     }
   })

--- a/store/index.js
+++ b/store/index.js
@@ -1,0 +1,118 @@
+import { Store } from 'vuex'
+
+import fetchCollection from '~/actions/fetchCollection'
+import combineCollections from '~/actions/combineCollections'
+import LocalStorage from '~/components/LocalStorage'
+
+const localStorage = new LocalStorage()
+
+const getInitialFilters = (routeQuery = {}) => ({
+  bestnum: routeQuery.bestnum || null,
+  maxweight: routeQuery.maxweight || null,
+  minweight: routeQuery.minweight || null,
+  mintime: routeQuery.mintime || null,
+  maxtime: routeQuery.maxtime || null,
+  mechShow: null,
+  mechHide: null,
+  ownedgames: null,
+  playlessthan: routeQuery.playlessthan || null,
+  recnum: routeQuery.recnum || null,
+  showexp: null,
+  showOwned: null,
+  supplayer: routeQuery.suppplayer || null
+})
+
+const createStore = () => {
+  return new Store({
+    state: {
+      filters: {
+        ...getInitialFilters()
+      },
+      views: {
+        listView: true
+      },
+      items: {},
+      pageState: {}
+    },
+    mutations: {
+      'filters/reset' (state, routeQuery) {
+        state.filters = {
+          ...getInitialFilters(routeQuery)
+        }
+      },
+      'filters/set' (state, filters) {
+        state.filters = filters
+      },
+      'filters/set/field' (state, filterField, filterValue) {
+        state.filters[filterField] = filterValue
+      },
+      'filters/setOwned' (state, filterValue = null) {
+        state.filters.ownedgames = filterValue
+      },
+      'views/toggleListView' (state) {
+        state.views.listView = !state.views.listView
+      },
+      'items/query/fetch': (state, key) => {
+        state.items[key] = {}
+        state.pageState[key] = {
+          loaded: false
+        }
+      },
+      'items/query/done': (state, { key, val }) => {
+        state.items = {
+          ...state.items,
+          [key]: val
+        }
+        state.pageState = {
+          [key]: {
+            ...(state.pageState[key] || {}),
+            loaded: true,
+            error: false
+          }
+        }
+      },
+      'items/query/error': (state, { key, err }) => {
+        console.log(key, err)
+        state.pageState = {
+          [key]: {
+            ...(state.pageState[key] || {}),
+            loaded: true,
+            error: true,
+            errorMessage: err
+          }
+        }
+      }
+    },
+    actions: {
+      'items/query/fetch/index': async ({ commit }, userId) => {
+        commit('items/query/fetch', 'index')
+        const ids = userId.split(',').slice(0, 9)
+        const collections = await Promise.all(ids.map(async id => {
+          const stored = localStorage.get(`collection/${id}`)
+          if (stored) {
+            return stored
+          }
+          const result = await fetchCollection(id)
+          try {
+            localStorage.set(`collection/${id}`, result)
+          } catch (e) {
+            console.error(e)
+          }
+          return result
+        })).catch((res) => {
+          console.error(res)
+          if (res.config) {
+            commit('items/query/error', { key: 'index', err: `Waiting for BGG to process for user "${res.config.params.username}". Please try again later for access.` })
+          } else {
+            commit('items/query/error', res.message)
+          }
+        })
+        if (collections) {
+          commit('items/query/done', { key: 'index', val: combineCollections(collections) })
+        }
+      }
+    }
+  })
+}
+
+export default createStore

--- a/utils/debug.js
+++ b/utils/debug.js
@@ -1,0 +1,8 @@
+
+export default function debug (...args) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.group('debug')
+    args.forEach(val => console.log(val))
+    console.groupEnd('debug')
+  }
+}


### PR DESCRIPTION
This adds support for caching API requests, and in doing so, does the following:

- Stores API request responses in local storage
- Moves API request to separate action file
- Adds `combineCollections` to parse a set of collections (including only one collection).
  - As a result of this, we should be able to add support for showing multiple wishlists, want-to-play pages, etc.

This also includes the work done in the scope of #3, as it accomplished Vuex store setup.

For gameshelf/gameshelf.github.io#34

Remaining effort:

- [x] Add caching to "Want to Play" page
- [x] Add caching to "Wishlist" page
- [x] Add caching to "Trade/Sale" page
- [x] Add mechanism to clear cache from Help page
- [x] Add mechanism to attempt a re-fetch when the cache is state, then clear on success